### PR TITLE
Exclude non-site files

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -18,6 +18,9 @@ compass:
   # Tracking Code to that file.
   include_analytics: false
 
+# exclude
+exclude: ["CNAME", "Gemfile", "Gemfile.lock", "LICENSE", "README.md"]
+
 # Dependencies
 markdown: kramdown
 highlighter: rouge


### PR DESCRIPTION
This patch removes unnecessary repository files (README, LICENSE, etc.) from the published site.