### PR TITLE
use https instead of http to fix the issue of linking to google fonts "fonts.googleapis.com/css?family=Vollkorn"

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,7 +9,7 @@ compass:
   # author will appear under the avatar (optional)
   author: "Compass"
   # tagline will appear under the title (optional)
-  tagline: "The <a href='http://jekyllrb.com'>Jekyll</a> theme for your personal landing page"
+  tagline: "Software Engineer"
   # if include_content is true, the contents of the content.html include will be
   # added right above the generated item list, if present
   include_content: true

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -9,7 +9,7 @@
   <link rel="stylesheet" href="{{ site.baseurl }}/assets/normalize.css">
   <link rel="stylesheet" href="{{ site.baseurl }}/assets/main.css">
   <link href="//maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css" rel="stylesheet">
-  <link href='http://fonts.googleapis.com/css?family=Vollkorn' rel='stylesheet' type='text/css'>
+  <link href='https://fonts.googleapis.com/css?family=Vollkorn' rel='stylesheet' type='text/css'>
 
   <link rel="canonical" href="{{ site.url }}{{ page.url }}">
 


### PR DESCRIPTION
Failed to load the google font "Vollkorn" specified in head.html Due to using http instead of https.