### PR TITLE
Update head.html to include theme color

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -40,4 +40,7 @@
   {% if site.compass.include_analytics %}
   {% include analytics.html %}
   {% endif %}
+
+<meta name="theme-color" content="#F1EED9">
+
 </head>


### PR DESCRIPTION
This should allow mobile browsers to change the color of the URL bar to match the background color present in the main css.

I also think I may have messed up the indentation on the lines preceeding and following the code. If so, it might make the code neater if it were edited. 